### PR TITLE
Update geospatial metadata only if it is INSPIRE data/service

### DIFF
--- a/ckanext/scheming_dcat/templates/package/read_base.html
+++ b/ckanext/scheming_dcat/templates/package/read_base.html
@@ -1,6 +1,18 @@
 {% ckan_extends %}
+{#
+  geospatial_metadata_values: Sublist of dcat_type_values that has geospatial metadata (INSPIRE Register).
+#}
+{%- set geospatial_metadata_values = [
+  'http://inspire.ec.europa.eu/metadata-codelist/ResourceType/dataset',
+  'http://inspire.ec.europa.eu/metadata-codelist/ResourceType/series',
+  'http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service'
+] -%}
+
 {% block content_primary_nav %}
   {{ super() }}
   {{ h.build_nav_icon('scheming_dcat.index', _('Linked Data'), id=pkg.id if is_activity_archive else pkg.name, icon='asterisk') }}
-  {{ h.build_nav_icon('scheming_dcat.geospatial_metadata', _('Geospatial Metadata'), id=pkg.id if is_activity_archive else pkg.name, icon='globe') }}
+
+  {% if pkg.dcat_type in geospatial_metadata_values %}
+    {{ h.build_nav_icon('scheming_dcat.geospatial_metadata', _('Geospatial Metadata'), id=pkg.id if is_activity_archive else pkg.name, icon='globe') }}
+  {% endif %}
 {% endblock %}

--- a/ckanext/scheming_dcat/templates/scheming_dcat/package/read_base.html
+++ b/ckanext/scheming_dcat/templates/scheming_dcat/package/read_base.html
@@ -2,9 +2,6 @@
 
 {% block secondary_content %}
   {{ super() }}
-
-  // Standard version: "{% set dataset_extent = h.get_pkg_dict_extra(c.pkg_dict, 'spatial', '') %}"
-  // CKAN Docker Compose version: "{% set dataset_extent = pkg.spatial %}"
   {% set dataset_extent = pkg.spatial %}
   {% if dataset_extent %}
     {% snippet "spatial/snippets/dataset_map_sidebar.html", extent=dataset_extent %}


### PR DESCRIPTION
The geospatial metadata page in a dataset only shows if the dcat_type of the package is an INSPIRE metadata (dataset, series or service).